### PR TITLE
Don't indent single-line contraints more than need be

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Will not correctly parse:
 
 - Thinarrow is not parsed yet. And possibly others syntax elements.
 - Add tests with malformed content.
-- promise guards don't have classguards as children.
+- promise guards don't have classguards as children, and they should.
 
 ## Usage
 

--- a/ast/cfengine.go
+++ b/ast/cfengine.go
@@ -19,7 +19,6 @@ type (
 	Promiser      struct{ Container }
 	Selection     struct{ Container }
 	Qstring       struct{ Leaf }
-	Constraint    struct{ Container }
 	FatArrow      struct{ Leaf }
 	ThinArrow     struct{ Leaf }
 	Function      struct{ Container }
@@ -29,4 +28,8 @@ type (
 	ListItem      struct{ Leaf }
 	ArgList       struct{ Container }
 	ArgListItem   struct{ Leaf }
+	Constraint    struct {
+		Container
+		SingleLine bool // True when we want to print this on a single line.
+	}
 )

--- a/lex.go
+++ b/lex.go
@@ -230,10 +230,6 @@ func scanLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		return 0, nil, nil
 	}
 	if i := bytes.IndexByte(data, '\n'); i >= 0 {
-		// We have a full newline-terminated line.
-		if data[0] == '"' {
-			println("QUOTE")
-		}
 		return i + 1, trim(data[0:i]), nil
 	}
 	// If we're at EOF, we have a final, non-terminated line. Return it.

--- a/pretty_test.go
+++ b/pretty_test.go
@@ -34,7 +34,7 @@ func TestPrettyPrint(t *testing.T) {
 		spec, err := Parse(l)
 		r.Close()
 		if err != nil {
-			t.Errorf("failed to parse document: %s", err)
+			t.Fatalf("failed to parse document: %s", err)
 			continue
 		}
 
@@ -50,7 +50,7 @@ func TestPrettyPrint(t *testing.T) {
 		}
 
 		if doc.String() != string(pretty) {
-			t.Errorf("Pretty print of %s, doesn't match", f.Name())
+			t.Fatalf("Pretty print of %s, doesn't match", f.Name())
 		}
 	}
 }

--- a/testdata/dump.pretty
+++ b/testdata/dump.pretty
@@ -3,27 +3,27 @@ bundle agent dumpcapabilities
 {
   classes:
 
-    "getcapExists"       expression => fileexists("/sbin/getcap");
+    "getcapExists"  expression => fileexists("/sbin/getcap");
 
-    "setcapExists"       expression => fileexists("/sbin/setcap");
+    "setcapExists"  expression => fileexists("/sbin/setcap");
 
-    "dumpcapExists"      expression => fileexists("/usr/bin/dumpcap");
+    "dumpcapExists" expression => fileexists("/usr/bin/dumpcap");
 
-    "tcpdumpExists"      expression => fileexists("/usr/sbin/tcpdump");
+    "tcpdumpExists" expression => fileexists("/usr/sbin/tcpdump");
 
   getcapExists.dumpcapExists::
-    "FileCapOnDumpcap"      expression => returnszero("/sbin/getcap  /usr/bin/dumpcap  | grep -q '^/usr/bin/dumpcap = cap_net_admin,cap_net_raw+eip$'", "useshell");
+    "FileCapOnDumpcap" expression => returnszero("/sbin/getcap  /usr/bin/dumpcap  | grep -q '^/usr/bin/dumpcap = cap_net_admin,cap_net_raw+eip$'", "useshell");
 
   getcapExists.tcpdumpExists::
-    "FileCapOnTcpdump"      expression => returnszero("/sbin/getcap  /usr/sbin/tcpdump | grep -q '^/usr/sbin/tcpdump = cap_net_admin,cap_net_raw+eip$'", "useshell");
+    "FileCapOnTcpdump" expression => returnszero("/sbin/getcap  /usr/sbin/tcpdump | grep -q '^/usr/sbin/tcpdump = cap_net_admin,cap_net_raw+eip$'", "useshell");
 
   files:
 
   dumpcapExists::
-    "/usr/bin/dumpcap"      perms => mog(0555, root, root);
+    "/usr/bin/dumpcap" perms => mog(0555, root, root);
 
   tcpdumpExists::
-    "/usr/sbin/tcpdump"      perms => mog(0555, root, root);
+    "/usr/sbin/tcpdump" perms => mog(0555, root, root);
 
   HasDumpCapabilities::
 

--- a/testdata/list.pretty
+++ b/testdata/list.pretty
@@ -2,11 +2,11 @@ bundle agent one
 {
   reports:
 
-    "is_var"      if => isvariable("five");
+    "is_var" if => isvariable("five");
 
-    "two"         depends_on => { "handle_one", "handle_two" };
+    "two"    depends_on => { "handle_one", "handle_two" };
 
-    "one"         handle => "handle_one";
+    "one"    handle => "handle_one";
 
-    "three"       handle => "10.5";
+    "three"  handle => "10.5";
 }


### PR DESCRIPTION
Don't blindly insert 'indent' when printing one a single line, just use
a single space.

This leads to more compact code and no weird spacing being inserted.

Signed-off-by: Miek Gieben <miek@miek.nl>
