### PR TITLE
Added policy containing macros to unparseable

### DIFF
--- a/unparseable/macro.cf
+++ b/unparseable/macro.cf
@@ -1,0 +1,21 @@
+bundle agent macro_test
+{
+  vars:
+      "path" # path to search up from
+        string => "/tmp/";
+      "glob" # glob pattern matching filename
+        string => ".git/config";
+      "level" # how far to search
+        int => "inf";
+
+@if minimum_version(3.18) # find files up was
+      "configs"
+        data => findfiles_up("$(path)", "$(glob)", "$(level)");
+@endif
+
+  reports:
+      "Submodules '$(glob)' is located in '$(configs[0])'"
+        if => isvariable("configs");
+      "Parents '$(glob)' is located in '$(configs[1])'"
+        if => isvariable("configs");
+}


### PR DESCRIPTION
Hi Miek, tested your parser and found some policy that the parser could not handle :)

cffmt is not able to parse unparseable/macro.cf

```
$ cffmt unparseable/macro.cf
2023/03/03 14:02:41 unparseable/macro.cf:11:1: error while parsing (left in buffer: "if minimum_version(3.18) # find files up was"): syntax error
```

cf-promises is able to parse unparseable/macro.cf

```
$ cf-promises unparseable/macro.cf
```

Also running the program with no arguments, causes it to halt
```
$ cffmt 
```