### PR TITLE
Fix infinite loop

### DIFF
--- a/cmd/cffmt/cffmt.1
+++ b/cmd/cffmt/cffmt.1
@@ -31,12 +31,6 @@ show lexer tokens
 if parsing fails only show the name of the file being parsed.
 
 
-.SH "BUGS"
-.PP
-A comment as the last list item will cause infinite
-recursion
-\[la]https://github.com/miekg/cf/issues/11\[ra].
-
 .SH "AUTHOR"
 .PP
 Miek Gieben miek@miek.nl

--- a/cmd/cffmt/cffmt.1.md
+++ b/cmd/cffmt/cffmt.1.md
@@ -33,11 +33,6 @@ Options are:
 `-f`
 :   if parsing fails only show the name of the file being parsed.
 
-## Bugs
-
-A comment as the last list item will cause [infinite
-recursion](https://github.com/miekg/cf/issues/11).
-
 ## Author
 
 Miek Gieben <miek@miek.nl>.

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -297,6 +297,7 @@ func Litems(b *rd.Builder) (ok bool) {
 	}
 
 More:
+	Comment(b)
 	Litem(b)
 
 	// next token is , we have more Litems, otherwise return

--- a/internal/parse/print.go
+++ b/internal/parse/print.go
@@ -272,7 +272,7 @@ func print(w *tw, t *rd.Tree, depth int, parent *rd.Tree) {
 			if len(t.Subtrees) == 0 {
 				fmt.Fprintf(w, "}")
 			} else {
-				fmt.Fprintf(w, " }")
+				fmt.Fprint(w, " }")
 			}
 			w.bracecol = -1
 

--- a/testdata/comment-as-last-listitem.cf
+++ b/testdata/comment-as-last-listitem.cf
@@ -1,0 +1,7 @@
+body common control
+{
+      bundlesequence => {
+                          @(update_def.bundlesequence_end),
+                          # Define control_common_update_bundlesequnce_end via augments
+      };
+}


### PR DESCRIPTION
Fix the infinite recursion by eating a possible comment (single) as a
list-item. Add test-case as well.

Closes #11

Signed-off-by: Miek Gieben <miek@miek.nl>
