### PR TITLE
Fix promisee when no contraints

### DIFF
--- a/internal/parse/print.go
+++ b/internal/parse/print.go
@@ -260,7 +260,11 @@ func (p *Printer) print(w *tw, t *rd.Tree, depth int, parent *rd.Tree) {
 			fmt.Fprint(w, ":\n\n")
 
 		case "Promisee":
-			fmt.Fprintf(w, "\n%s", indent)
+			// there are constraints following this promisee, add a newline
+			// if not don't, so the closing ; will be put on the same line.
+			if len(parent.Subtrees) > 2 {
+				fmt.Fprintf(w, "\n%s", indent)
+			}
 
 		case "ClassGuardPromises":
 

--- a/testdata/promisee.cf
+++ b/testdata/promisee.cf
@@ -1,0 +1,4 @@
+bundle agent bogus {
+    reports:
+        "Hello CFEngine" -> { "foo", "bar", "baz" };
+}

--- a/testdata/promisee.cf.pretty
+++ b/testdata/promisee.cf.pretty
@@ -1,0 +1,6 @@
+bundle agent bogus
+{
+  reports:
+
+    "Hello CFEngine" -> { "foo", "bar", "baz" };
+}

--- a/testdata/thinarrow.cf.pretty
+++ b/testdata/thinarrow.cf.pretty
@@ -1,0 +1,8 @@
+bundle agent cfengine_internal_standalone_self_upgrade_execution
+{
+  reports:
+
+    inform_mode|verbose_mode|DEBUG|DEBUG_cfengine_internal_standalone_self_upgrade::
+      "Skipped self upgrade because we are running the desired version $(sys.cf_version)" -> { "ENT-3592" }
+         if => "at_desired_version";
+}


### PR DESCRIPTION
If there are no constraints don't insert a newline so the closing
semicolon is neatly printed on the same line.

Fixes: #29

Signed-off-by: Miek Gieben <miek@miek.nl>
