### PR TITLE
Fix multiple comments

### DIFF
--- a/testdata/multiple-comment.cf
+++ b/testdata/multiple-comment.cf
@@ -1,0 +1,7 @@
+# Licensed under the MIT License
+# Copyright (c) 2023 Lars Erik Wik
+
+# Run the bogus bundle first, then doofus
+body common control {
+    bundlesequence => { "bogus", "doofus" };
+}

--- a/testdata/multiple-comment.cf.pretty
+++ b/testdata/multiple-comment.cf.pretty
@@ -1,0 +1,8 @@
+# Licensed under the MIT License
+# Copyright (c) 2023 Lars Erik Wik
+
+# Run the bogus bundle first, then doofus
+body common control
+{
+  bundlesequence => { "bogus", "doofus" };
+}


### PR DESCRIPTION
This is now "fixed" by inserting a newline, was could not be have been the intent (there could have been multple newlines), otoh, this neatly compacts the file.

Fixes: #25