### PR TITLE
Be slightly smarter when comments are put in a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ original input will be outputted instead.
 
 If you have an `slist` in a contraint you can put `# cffmt:list-nl` above it if you want each item
 to be printed on a new line.
+If a list has less then 10 items *and* at least one of these items is a comment, it will be printed
+as if `cffmt:list-nl` has been given.
 
 If you have a "normal" looking CFEngine file that isn't parsed correctly, please open an issue with
 the _most_ _minimal_ CFEngine syntax that fails to parse.

--- a/internal/parse/print.go
+++ b/internal/parse/print.go
@@ -140,6 +140,11 @@ func (p *Printer) print(w *tw, t *rd.Tree, depth int, parent *rd.Tree) {
 				fmt.Fprintf(w, "{ ")
 			}
 			w.bracecol = w.col
+			litems := countOfType(t, "Litem")
+			comments := countOfType(t, "Comment")
+			if litems+comments <= 10 && comments > 0 {
+				p.multilineList = true
+			}
 
 		case "Litem":
 		}
@@ -224,7 +229,9 @@ func (p *Printer) print(w *tw, t *rd.Tree, depth int, parent *rd.Tree) {
 					fmt.Fprintf(w, "%s", lindent)
 				}
 			}
-			p.multilineList = strings.HasPrefix(v.Value, "# cffmt:list-nl")
+			if strings.HasPrefix(v.Value, "# cffmt:list-nl") {
+				p.multilineList = true
+			}
 
 		case token.Qstring:
 			// TODO(miek): Needs indenting if spread over multiple lines. Possibly we need to strip prefix
@@ -328,6 +335,7 @@ func (p *Printer) print(w *tw, t *rd.Tree, depth int, parent *rd.Tree) {
 				fmt.Fprint(w, " }")
 			}
 			w.bracecol = -1
+			p.multilineList = false
 
 		case "Litem":
 			last := lastOfType(parent, t, "Litem")

--- a/testdata/body-list-comments.cf
+++ b/testdata/body-list-comments.cf
@@ -1,0 +1,8 @@
+body common control {
+    bundlesequence => {
+        # "foo",
+        "bogus",
+        # "bar",
+        "doofus",
+    };
+}

--- a/testdata/body-list-comments.cf.pretty
+++ b/testdata/body-list-comments.cf.pretty
@@ -1,0 +1,7 @@
+body common control
+{
+  bundlesequence => {   # "foo",
+                      "bogus",
+                        # "bar",
+                      "doofus" };
+}


### PR DESCRIPTION
This checks if a list contains commments and has less then 10 item (arbitrary number). It will then assume a multiline list and print each item on a new line.

Sortof fixes #27 and probably the best I can do without too much hackery.

Fixes: #27