### PR TITLE
Changed path for executing cffmt to the default bin directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Install the `cffmt` binary with: `go install github.com/miekg/cf/cmd/cffmt@main`
 giving it a filename or piping to standard input. The pretty printed document is printed to standard
 output.
 
-    ./cffmt ../../testdata/promtest.cf
+    ~/go/bin/cffmt ../../testdata/promtest.cf
 
 ## Abstract Syntax Tree
 


### PR DESCRIPTION
I had to do a bit of searching to figure out where `./` was after following the
instructions for installing it.

This change adjusts the path for cffmt to use the default path where the binary
is found if you install using the provided instructions.