### PR TITLE
align better

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,10 +8,10 @@ jobs:
     steps:
 
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build
       run: go build -v ./...

--- a/testdata/promise-keyword-align.cf
+++ b/testdata/promise-keyword-align.cf
@@ -1,0 +1,8 @@
+bundle agent nftables
+{
+  vars:
+
+    any.HasNfTables::
+      "path" string         => "etc/nftables.conf.d";
+      "acls"    slist  => getindices("acl");
+}

--- a/testdata/promise-keyword-align.cf.pretty
+++ b/testdata/promise-keyword-align.cf.pretty
@@ -1,0 +1,8 @@
+bundle agent nftables
+{
+  vars:
+
+    any.HasNfTables::
+      "path" string => "etc/nftables.conf.d";
+      "acls" slist  => getindices("acl");
+}


### PR DESCRIPTION
This:

    any.HasNfTables::
      "path"     string => "etc/nftables.conf.d";
      "acls"     slist => getindices("acl");

will now be aligned to:

    any.HasNfTables::
      "path" string => "etc/nftables.conf.d";
      "acls" slist  => getindices("acl");

Signed-off-by: Miek Gieben <miek@miek.nl>
