### PR TITLE
Coalescing comments doens't work

### DIFF
--- a/cfengine.go
+++ b/cfengine.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/alecthomas/chroma/v2"
 	"github.com/miekg/cf/internal/parse"
-	"github.com/miekg/cf/internal/token"
 	"github.com/shivamMg/rd"
 )
 
@@ -46,7 +45,7 @@ func IsNoParse(tokens []rd.Token) bool {
 	}
 
 	if ct, ok := tokens[0].(chroma.Token); ok {
-		if ct.Type == token.Comment && strings.HasPrefix(ct.Value, "# cffmt:no") {
+		if ct.Type == chroma.Comment && strings.HasPrefix(ct.Value, "# cffmt:no") {
 			return true
 		}
 	}

--- a/internal/parse/lex.go
+++ b/internal/parse/lex.go
@@ -14,10 +14,7 @@ func Lex(specification string) ([]rd.Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	// There are several passes here. Mostly to not have a very complex single loop. Surely this can be optimized,
-	// OTOH it's only iterating over a few thousand tokens and creating a bunch of garbage memory.
-
-	// Compresses LiteralString* into a single Qstring, same for Comments.
+	// Compresses LiteralString* into a single Qstring
 	pt := chroma.Token{Type: token.None}
 	//defer println("*****")
 	for _, t := range iter.Tokens() {
@@ -29,15 +26,6 @@ func Lex(specification string) ([]rd.Token, error) {
 				pt.Value = ""
 			}
 			pt.Type = token.Qstring
-			pt.Value += t.Value
-
-		case chroma.Comment:
-			if pt.Type != token.Comment && pt.Type != token.None {
-				tokens = append(tokens, rd.Token(pt))
-				pt.Value = ""
-			}
-
-			pt.Type = token.Comment
 			pt.Value += t.Value
 
 		case chroma.Operator:

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -442,7 +442,7 @@ func Comment(b *rd.Builder) (ok bool) {
 	b.Enter("Comment")
 	defer b.Exit(&ok)
 
-	return MatchType(b, token.Comment)
+	return MatchType(b, chroma.Comment)
 }
 
 func Fmt(b *rd.Builder, a string, i int) {

--- a/internal/parse/print.go
+++ b/internal/parse/print.go
@@ -112,11 +112,7 @@ func (p *Printer) print(w *tw, t *rd.Tree, depth int, parent *rd.Tree) {
 				if constraintPreventSingleLine(t) {
 					fmt.Fprintf(w, "\n%s", indent)
 				} else {
-					if prevOfType(parent, t, "Comment") { // we have insert a new line then
-						fmt.Fprintf(w, "%s", indent)
-					} else {
-						fmt.Fprint(w, " ")
-					}
+					fmt.Fprint(w, " ")
 				}
 			} else {
 				fmt.Fprintf(w, "\n%s", indent)
@@ -189,7 +185,7 @@ func (p *Printer) print(w *tw, t *rd.Tree, depth int, parent *rd.Tree) {
 		case chroma.LiteralNumberInteger:
 			fmt.Fprintf(w, "%s", v.Value)
 
-		case token.Comment:
+		case chroma.Comment:
 			// Comments are nested as a child of ClassPromise. This makes them slighty too indented by one
 			// step. Fix that here. FIX(miek).
 			switch depth {

--- a/internal/parse/tree.go
+++ b/internal/parse/tree.go
@@ -59,25 +59,6 @@ func sequenceOfChild(parent, child *rd.Tree) int {
 	return -1
 }
 
-// is the previous sibling of parent of type t.
-func prevOfType(parent, child *rd.Tree, t string) bool {
-	var p *rd.Tree
-	for _, c := range parent.Subtrees {
-		if c == child {
-			if p == nil {
-				return false
-			}
-			if s, ok := p.Data().(string); ok {
-				if s == t {
-					return true
-				}
-			}
-		}
-		p = c
-	}
-	return false
-}
-
 func firstOfType(parent, child *rd.Tree, t string) bool {
 	return ofType(parent.Subtrees, child, t)
 }

--- a/internal/token/tokens.go
+++ b/internal/token/tokens.go
@@ -1,11 +1,10 @@
 package token
 
 // Extra tokens we use in CFEngine, these tokens are slightly higher level than the tokens Chroma
-// returns. For instance LiteralStrings are group together to become Qstrings, as do Comments.
+// returns. For instance LiteralStrings are group together to become Qstrings.
 const (
 	None      = iota - 1000
 	FatArrow  = -996
 	ThinArrow = -995
 	Qstring   = -994
-	Comment   = -993
 )

--- a/testdata/single-quote-comment.cf
+++ b/testdata/single-quote-comment.cf
@@ -2,6 +2,6 @@ bundle agent autofs
 {
  vars:
 
-   "automaster_lines"  slist => { '#controlled by cfengine', # actual comment
+   "automaster_lines"  slist => { '#controlled by cfengine',
 								};
 }

--- a/testdata/single-quote-comment.cf
+++ b/testdata/single-quote-comment.cf
@@ -2,6 +2,6 @@ bundle agent autofs
 {
  vars:
 
-   "automaster_lines"  slist => { '#controlled by cfengine',
+   "automaster_lines"  slist => { '#controlled by cfengine', # actual comment
 								};
 }


### PR DESCRIPTION
The indentation whitespace make it so that each comment is inserted as a
single token anyway, so it only works outside of bodies and bundles,
also didn't have a testcase for some if-then comment code, so ripped
that out as well.

Signed-off-by: Miek Gieben <miek@miek.nl>
