### PR TITLE
Bring back prevOfType

### DIFF
--- a/internal/parse/print.go
+++ b/internal/parse/print.go
@@ -112,7 +112,11 @@ func (p *Printer) print(w *tw, t *rd.Tree, depth int, parent *rd.Tree) {
 				if constraintPreventSingleLine(t) {
 					fmt.Fprintf(w, "\n%s", indent)
 				} else {
-					fmt.Fprint(w, " ")
+					if prevOfType(parent, t, "Comment") { // we have insert a new line then
+						fmt.Fprintf(w, "%s", indent)
+					} else {
+						fmt.Fprint(w, " ")
+					}
 				}
 			} else {
 				fmt.Fprintf(w, "\n%s", indent)

--- a/internal/parse/tree.go
+++ b/internal/parse/tree.go
@@ -59,6 +59,25 @@ func sequenceOfChild(parent, child *rd.Tree) int {
 	return -1
 }
 
+// is the previous sibling of parent of type t.
+func prevOfType(parent, child *rd.Tree, t string) bool {
+	var p *rd.Tree
+	for _, c := range parent.Subtrees {
+		if c == child {
+			if p == nil {
+				return false
+			}
+			if s, ok := p.Data().(string); ok {
+				if s == t {
+					return true
+				}
+			}
+		}
+		p = c
+	}
+	return false
+}
+
 func firstOfType(parent, child *rd.Tree, t string) bool {
 	return ofType(parent.Subtrees, child, t)
 }

--- a/testdata/qstring-as-classguard.cf.pretty
+++ b/testdata/qstring-as-classguard.cf.pretty
@@ -1,0 +1,8 @@
+bundle agent example
+{
+  files:
+
+    "$(input)"::
+      "/tmp/web"  # Directory to monitor for changes.
+        classes => kept_repaired_failed("promise_kept", "promise_repaired", "promise_not_kept)");
+}


### PR DESCRIPTION
It was used after a comment, to aling the next line. Add .pretty test
case to catch this.

Signed-off-by: Miek Gieben <miek@miek.nl>
