### PR TITLE
Spacing for ClassGuardPromise

### DIFF
--- a/internal/parse/print.go
+++ b/internal/parse/print.go
@@ -77,6 +77,9 @@ func (p *Printer) print(w *tw, t *rd.Tree, depth int, parent *rd.Tree) {
 
 		case "ClassGuardPromises":
 			first := firstOfType(parent, t, "ClassGuardPromises")
+			if first { // double check if we really didn't have something above
+				first = sequenceOfChild(parent, t) == 0
+			}
 			if !first {
 				fmt.Fprintln(w)
 			}

--- a/testdata/ldap.cf
+++ b/testdata/ldap.cf
@@ -1,0 +1,15 @@
+bundle agent ldap_server
+{
+  files:
+
+    "/etc/ldap/schema/rfc2307bis.schema"
+      copy_from => no_backup_rdcp("$(def.distr_files_dir)/etc/ldap/schema/rfc2307bis.schema", $(sys.policy_hub)),
+      perms     => mog(0644, root, root),
+      classes   => if_repaired("slapd_updated");
+
+    IsLdapServer.ubuntu_20::
+      "/var/lib/ldap/."
+        create => "true",
+        perms  => mog(0750, openldap, openldap);
+
+}

--- a/testdata/ldap.cf.pretty
+++ b/testdata/ldap.cf.pretty
@@ -1,0 +1,14 @@
+bundle agent ldap_server
+{
+  files:
+
+    "/etc/ldap/schema/rfc2307bis.schema"
+      copy_from => no_backup_rdcp("$(def.distr_files_dir)/etc/ldap/schema/rfc2307bis.schema", $(sys.policy_hub)),
+      perms     => mog(0644, root, root),
+      classes   => if_repaired("slapd_updated");
+
+    IsLdapServer.ubuntu_20::
+      "/var/lib/ldap/."
+        create => "true",
+        perms  => mog(0750, openldap, openldap);
+}


### PR DESCRIPTION
When there is "something" above, output a newline, otherwise inhibit it. Add ldap.cf and ldap.cf.pretty to test this.